### PR TITLE
Fix: Slugify tags on papers

### DIFF
--- a/_includes/paper.html
+++ b/_includes/paper.html
@@ -1,7 +1,8 @@
 {% assign categories="" | split: "," %}
 {% for tag in paper.tags %}
 {% if tag.type != 1 %}
-{% assign categories=categories | push: tag.tag %}
+{% assign tag_slugified=tag.tag | slugify %}
+{% assign categories=categories | push: tag_slugified %}
 {% endif %}
 {% endfor %}
 {% assign paper=include.paper %}


### PR DESCRIPTION
Tags with whitespace would break on the `impact` page because the `data-filter` property on the paper item would not have been slugified before assignment:

eg. the `Miniscope V3` button was looking for `miniscope-v3`:

<img width="549" alt="Screenshot 2024-07-22 at 4 30 58 PM" src="https://github.com/user-attachments/assets/9530c28f-651c-49ab-992d-993ea7994b58">

but the paper items would have `Miniscope V3`:

<img width="573" alt="Screenshot 2024-07-22 at 4 31 35 PM" src="https://github.com/user-attachments/assets/a6e2479e-3810-4412-89d7-f363979424d9">

so we just slugify the tag before adding it to the array 
